### PR TITLE
Creating directory for backup within the backup script

### DIFF
--- a/Synology_Plex_Backup.sh
+++ b/Synology_Plex_Backup.sh
@@ -126,6 +126,9 @@ esac
 
 
 #--------------------------------------------------------------------------
+# Create backup directory if not exists yet
+mkdir - p "$Backup_Directory"
+
 # Set temporary log filenames (we get the Plex version later)
 
 # Set backup filename


### PR DESCRIPTION
Hi,

First of all - thanks for your work and your interesting ideas!

Recently I've tried to re-use your solution for backup Plex application and faced with the (sad) fact, that destination directory must be created before script's execution; so, I've added line of code to your script to do it without prompt.

Please review it if you have time for this, maybe you'll include it into your original script.

Regards,
Alex
